### PR TITLE
Update to latest sauce-tunnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "sauce-tunnel": "2.0.x"
+    "sauce-tunnel": "2.2.x"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.9.2",


### PR DESCRIPTION
This will make the plugin run Sauce Connect 4.3.7 instead of 4.2.

Note the tests don't pass;  You can't bring up two instances of Sauce Connect without passing them different pidfiles, ports and so on.
